### PR TITLE
Allow trailing slash to be omitted in /facewall URL

### DIFF
--- a/app/application.coffee
+++ b/app/application.coffee
@@ -27,7 +27,7 @@ class Application
 
                 Backbone.history.start
                     pushState: true
-                    root: '/facewall/'
+                    root: '/facewall'
 
                 Object.freeze? @
 

--- a/app/assets/index.html
+++ b/app/assets/index.html
@@ -7,11 +7,11 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Facewall</title>
-    <link rel="shortcut icon" href="static/images/favicon.ico" />
+    <link rel="shortcut icon" href="/facewall/static/images/favicon.ico" />
     <meta name="viewport" content="width=device-width">
-    <link rel="stylesheet" href="static/css/app.css">
-    <script src="static/js/vendor.js"></script>
-    <script src="static/js/app.js"></script>
+    <link rel="stylesheet" href="/facewall/static/css/app.css">
+    <script src="/facewall/static/js/vendor.js"></script>
+    <script src="/facewall/static/js/app.js"></script>
     <script>require('initialize');</script>
 </head>
 <body>


### PR DESCRIPTION
This is a fix for #9. 2 changes:
1. Asset paths are made relative to the domain root rather than relative to the document, and
2. The Backbone router is initialized with `/facewall/` as the root instead of `/facewall/`.
